### PR TITLE
修改Decoration11 为 decoration11

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -30,7 +30,7 @@ export { default as Decoration7 } from './components/decoration7'
 export { default as Decoration8 } from './components/decoration8'
 export { default as Decoration9 } from './components/decoration9'
 export { default as Decoration10 } from './components/decoration10'
-export { default as Decoration11 } from './components/Decoration11'
+export { default as Decoration11 } from './components/decoration11'
 
 // charts
 export { default as Charts } from './components/charts'


### PR DESCRIPTION
组件导出入口文件

src/index.js 的 decoration11 组件的大小写写错了

将 33行 [Decoration11] 修改为 [decoration11]


**该PR的类型是？** (至少选择一个)

- [x] Bug修复


**是否在Chrome浏览器下进行过测试？**

- [x] 是

