### PR TITLE
add onScroll Method in scrollBoard, fix ISSUE #34

### DIFF
--- a/src/components/scrollBoard/index.js
+++ b/src/components/scrollBoard/index.js
@@ -151,7 +151,7 @@ function calcAligns(mergedConfig, header) {
   return deepMerge(aligns, align)
 }
 
-const ScrollBoard = forwardRef(({ onClick, config = {}, className, style, onMouseOver }, ref) => {
+const ScrollBoard = forwardRef(({ onClick, config = {}, className, style, onMouseOver, onScroll }, ref) => {
   const { width, height, domRef } = useAutoResize(ref)
 
   const [state, setState] = useState({
@@ -267,6 +267,11 @@ const ScrollBoard = forwardRef(({ onClick, config = {}, className, style, onMous
     if (start) yield new Promise(resolve => setTimeout(resolve, waitTime))
 
     const animationNum = carousel === 'single' ? 1 : rowNum
+
+    if (onScroll) { 
+      const { pause, resume } = task.current || {}
+      onScroll({ animationIndex, pause, resume, ele: task.current }) 
+    }
 
     let rows = rowsData.slice(animationIndex)
     rows.push(...rowsData.slice(0, animationIndex))
@@ -412,6 +417,7 @@ ScrollBoard.propTypes = {
   config: PropTypes.object,
   onClick: PropTypes.func,
   onMouseOver: PropTypes.func,
+  onScroll: PropTypes.func,
   className: PropTypes.string,
   style: PropTypes.object
 }


### PR DESCRIPTION
<!-- (将[ ]修改为[x]) -->

**该PR的类型是？** (至少选择一个)

- [ ] Bug修复
- [x] 新特性
- [ ] 新组件

**该PR是否向下兼容?** (选择任一)

- [x] 是
- [ ] 否

如果为否，请描述冲突情况:

**涉及到的ISSUE:**

- [ x ] 该PR如果涉及到某个ISSUE, 请在PR标题中描述出来 (例如. `fix #xxx[,#xxx]`, "xxx"为ISSUE序号)

**是否在Chrome浏览器下进行过测试？**

- [x] 是
- [ ] 否

如果这是一个**新特性**或**新组件**相关的PR，请提供如下信息

- [x] 添加该特性或组件的原因
- [ ] 文档应该修改哪些信息
- [ ] 测试相关

提交**新特性**或**新组件**前请先发起一个相关的ISSUE请求

如果不是单纯的数据轮播，想去控制根据滚动的数据和序号配合数据去动态控制轮播的暂停和继续，现在没有这个事件；
比如我是一个websocket 持续推送实时消息的来保证每次有新数据则滚动，如果没有新数据则不滚动，这个场景需要类似监听这个scroll的事件，并暴露pause 和resume的方法

**其他信息:**
